### PR TITLE
fix: Style resolving in production

### DIFF
--- a/experiments/rsc/scripts/configs/vite.mts
+++ b/experiments/rsc/scripts/configs/vite.mts
@@ -8,8 +8,10 @@ import { resolve } from "node:path";
 import {
   CLIENT_DIST_DIR,
   DEV_SERVER_PORT,
+  MANIFEST_PATH,
   RELATIVE_CLIENT_PATHNAME,
   RELATIVE_WORKER_PATHNAME,
+  SRC_DIR,
   VENDOR_DIST_DIR,
   WORKER_DIST_DIR,
 } from "../lib/constants.mjs";
@@ -22,6 +24,7 @@ import { useServerPlugin } from "../lib/vitePlugins/useServerPlugin.mjs";
 import { useClientPlugin } from "../lib/vitePlugins/useClientPlugin.mjs";
 import commonjsPlugin from "vite-plugin-commonjs";
 import { useClientLookupPlugin } from "../lib/vitePlugins/useClientLookupPlugin.mjs";
+import { transformJsxLinksTagsPlugin } from "../lib/vitePlugins/transformJsxLinksTagsPlugin.mjs";
 
 const MODE =
   process.env.NODE_ENV === "development" ? "development" : "production";
@@ -62,6 +65,7 @@ export const viteConfigs = {
           rollupOptions: {
             input: {
               client: RELATIVE_CLIENT_PATHNAME,
+              style: resolve(SRC_DIR, "app", "style.css"),
             },
           },
         },
@@ -123,7 +127,10 @@ export const viteConfigs = {
     mergeConfig(viteConfigs.main(), {
       plugins: [
         transformJsxScriptTagsPlugin({
-          manifestPath: resolve(CLIENT_DIST_DIR, ".vite/manifest.json"),
+          manifestPath: MANIFEST_PATH,
+        }),
+        transformJsxLinksTagsPlugin({
+          manifestPath: MANIFEST_PATH,
         }),
         useClientLookupPlugin({
           filesContainingUseClient,

--- a/experiments/rsc/scripts/lib/constants.mts
+++ b/experiments/rsc/scripts/lib/constants.mts
@@ -3,7 +3,9 @@ import { resolve } from "node:path";
 const __dirname = new URL(".", import.meta.url).pathname;
 
 export const ROOT_DIR = resolve(__dirname, "..", "..");
+export const SRC_DIR = resolve(ROOT_DIR, "src");
 export const DIST_DIR = resolve(ROOT_DIR, "dist");
+
 export const CLIENT_DIST_DIR = resolve(DIST_DIR, "client");
 export const WORKER_DIST_DIR = resolve(DIST_DIR, "worker");
 
@@ -12,7 +14,9 @@ export const VENDOR_DIST_DIR = resolve(ROOT_DIR, "vendor/dist");
 export const DEV_SERVER_PORT = 2332;
 export const WORKER_DEV_SERVER_PORT = 5174;
 
-export const RELATIVE_WORKER_PATHNAME = "src/worker.tsx";
-export const RELATIVE_CLIENT_PATHNAME = "src/client.tsx";
+export const RELATIVE_WORKER_PATHNAME = resolve(SRC_DIR, "worker.tsx");
+export const RELATIVE_CLIENT_PATHNAME = resolve(SRC_DIR, "client.tsx");
+
+export const MANIFEST_PATH = resolve(CLIENT_DIST_DIR, ".vite", "manifest.json");
 
 export const D1_PERSIST_PATH = resolve(ROOT_DIR, ".wrangler/state/v3/d1");

--- a/experiments/rsc/scripts/lib/vitePlugins/transformJsxLinksTagsPlugin.mts
+++ b/experiments/rsc/scripts/lib/vitePlugins/transformJsxLinksTagsPlugin.mts
@@ -1,0 +1,46 @@
+import MagicString from "magic-string";
+import { type Plugin } from "vite";
+import { readFile } from "node:fs/promises";
+import memoize from "lodash/memoize";
+import { pathExists } from "fs-extra";
+
+const readManifest = memoize(async (manifestPath: string) => {
+  return (await pathExists(manifestPath))
+    ? readFile(manifestPath, "utf-8").then(JSON.parse)
+    : {};
+});
+
+export const transformJsxLinksTagsPlugin = ({
+  manifestPath,
+}: {
+  manifestPath: string;
+}): Plugin => ({
+  name: "rw-reloaded-transform-jsx-link-tags",
+  async transform(code) {
+    const jsxLinkHrefRE =
+      /(jsx|jsxDEV)\("link",\s*{[^}]*rel:\s*["']stylesheet["'][^}]*href:\s*["']([^"']+)["'][^}]*}/g;
+
+    const matches = [...code.matchAll(jsxLinkHrefRE)];
+
+    if (!matches.length) {
+      return;
+    }
+
+    const manifest = await readManifest(manifestPath);
+    const s = new MagicString(code);
+
+    for (const match of matches) {
+      const href = match[2].slice("/".length);
+
+      if (manifest[href]) {
+        const transformedHref = manifest[href].file;
+        s.replaceAll(href, transformedHref);
+      }
+    }
+
+    return {
+      code: s.toString(),
+      map: s.generateMap(),
+    };
+  },
+});


### PR DESCRIPTION
Currently, when building, when we see this in jsx:
```
<script type="module" src="/src/client.tsx"></script>
```

We turn this into:
```
<script type="module" src="/assets/name-of-corresponding-entry-chunk.js"></script>
```

However, we don't do the same for stylesheets:

```
<link rel="stylesheet" href="/src/app/style.css" />
```

This PR fixes that.
