### PR TITLE
feat: Restart dev server on config changes

### DIFF
--- a/experiments/rsc/package.json
+++ b/experiments/rsc/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "npx tsx ./scripts/build.mts",
-    "dev": "NODE_ENV=development npx tsx ./scripts/runDevServer.mts",
+    "dev": "while true; do NODE_ENV=development npx tsx ./scripts/runDevServer.mts; [ $? -eq 0 ] || break; done",
     "seed": "pnpm wrangler d1 execute DB --file ./migrations/seed.sql",
     "migrate:dev": "npx wrangler d1 migrations apply DB --local",
     "migrate:prd": "npx wrangler d1 migrations apply DB --remote",

--- a/experiments/rsc/postcss.config.js
+++ b/experiments/rsc/postcss.config.js
@@ -3,4 +3,4 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/experiments/rsc/scripts/configs/vite.mts
+++ b/experiments/rsc/scripts/configs/vite.mts
@@ -24,10 +24,7 @@ import { transformJsxLinksTagsPlugin } from "../lib/vitePlugins/transformJsxLink
 import { miniflarePlugin } from "../lib/vitePlugins/miniflarePlugin/plugin.mjs";
 import { miniflareConfig } from "./miniflare.mjs";
 import { asyncSetupPlugin } from "../lib/vitePlugins/asyncSetupPlugin.mjs";
-import {
-  onUpdatePlugin,
-  restartPlugin,
-} from "../lib/vitePlugins/restartPlugin.mjs";
+import { restartPlugin } from "../lib/vitePlugins/restartPlugin.mjs";
 
 const MODE =
   process.env.NODE_ENV === "development" ? "development" : "production";
@@ -118,6 +115,13 @@ export const viteConfigs = {
         restartPlugin({
           filter: (filepath: string) =>
             !filepath.endsWith(".d.ts") &&
+            (filepath.endsWith(".ts") ||
+              filepath.endsWith(".tsx") ||
+              filepath.endsWith(".mts") ||
+              filepath.endsWith(".js") ||
+              filepath.endsWith(".mjs") ||
+              filepath.endsWith(".jsx") ||
+              filepath.endsWith(".json")) &&
             (filepath.startsWith(resolve(ROOT_DIR, "scripts")) ||
               dirname(filepath) === ROOT_DIR),
         }),

--- a/experiments/rsc/scripts/configs/vite.mts
+++ b/experiments/rsc/scripts/configs/vite.mts
@@ -1,11 +1,12 @@
 import { type InlineConfig, mergeConfig } from "vite";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import {
   CLIENT_DIST_DIR,
   DEV_SERVER_PORT,
   MANIFEST_PATH,
   RELATIVE_CLIENT_PATHNAME,
   RELATIVE_WORKER_PATHNAME,
+  ROOT_DIR,
   SRC_DIR,
   VENDOR_DIST_DIR,
   WORKER_DIST_DIR,
@@ -23,6 +24,10 @@ import { transformJsxLinksTagsPlugin } from "../lib/vitePlugins/transformJsxLink
 import { miniflarePlugin } from "../lib/vitePlugins/miniflarePlugin/plugin.mjs";
 import { miniflareConfig } from "./miniflare.mjs";
 import { asyncSetupPlugin } from "../lib/vitePlugins/asyncSetupPlugin.mjs";
+import {
+  onUpdatePlugin,
+  restartPlugin,
+} from "../lib/vitePlugins/restartPlugin.mjs";
 
 const MODE =
   process.env.NODE_ENV === "development" ? "development" : "production";
@@ -110,6 +115,12 @@ export const viteConfigs = {
     mergeConfig(viteConfigs.main(), {
       plugins: [
         asyncSetupPlugin({ setup }),
+        restartPlugin({
+          filter: (filepath: string) =>
+            !filepath.endsWith(".d.ts") &&
+            (filepath.startsWith(resolve(ROOT_DIR, "scripts")) ||
+              dirname(filepath) === ROOT_DIR),
+        }),
         miniflarePlugin({
           entry: RELATIVE_WORKER_PATHNAME,
           environment: "worker",

--- a/experiments/rsc/scripts/lib/getShortName.mts
+++ b/experiments/rsc/scripts/lib/getShortName.mts
@@ -1,0 +1,4 @@
+import { relative } from "node:path";
+
+export const getShortName = (file: string, root: string): string =>
+  file.startsWith(root) ? relative(root, file) : file;

--- a/experiments/rsc/scripts/lib/vitePlugins/asyncSetupPlugin.mts
+++ b/experiments/rsc/scripts/lib/vitePlugins/asyncSetupPlugin.mts
@@ -8,7 +8,7 @@ export const asyncSetupPlugin = ({
   let taskPromise = Promise.resolve(null as unknown);
 
   return {
-    name: "my-async-task-plugin",
+    name: "rw-reloaded-async-setup",
 
     // Hook into the configureServer to add middleware
     configureServer(server) {

--- a/experiments/rsc/scripts/lib/vitePlugins/restartPlugin.mts
+++ b/experiments/rsc/scripts/lib/vitePlugins/restartPlugin.mts
@@ -1,0 +1,61 @@
+import { HotUpdateOptions, Plugin } from "vite";
+import colors from "picocolors";
+import { getShortName } from "../getShortName.mjs";
+
+export const restartPlugin = ({
+  filter,
+}: {
+  filter: (filepath: string) => boolean;
+}): Plugin => {
+  let restarting = false;
+  let ready = false;
+
+  return {
+    name: "rw-reloaded-restart-dev-server",
+
+    async hotUpdate(ctx) {
+      // context(justinvdm, 12 Dec 2024): We're already restarting, so stop all hmr
+      if (restarting) {
+        return [];
+      }
+
+      // context(justinvdm, 12 Dec 2024): Server isn't ready yet, so pass on to next plugin
+      if (!ready) {
+        return;
+      }
+
+      if (filter(ctx.file)) {
+        restarting = true;
+        const shortName = getShortName(ctx.file, ctx.server.config.root);
+
+        this.environment.logger.info(
+          `${colors.green("restarting dev server")} ${colors.dim(shortName)}`,
+          {
+            clear: true,
+            timestamp: true,
+          },
+        );
+
+        // context(justinvdm, 2024-12-13):
+        // * This plugin assumes the dev server script will rerun if closed with a non-zero exit code
+        // (e.g. `while true; do NODE_ENV=development npx tsx dev.mts; [ $? -eq 0 ] || break; done`)
+        // * In the browser, the vite's HMR client will keeping retry reconnecting to the dev server
+        await ctx.server.close();
+
+        return [];
+      }
+    },
+    configureServer(server) {
+      // context(justinvdm, 12 Dec 2024): Wait until the server has responded to a test request
+      // before allowing the server to be restarted. Otherwise vite's HMR client retry mechanism
+      // won't yet be ready. Otherwise, if we restarted while the client was busy with a (so far successful)
+      // retry, a restart would cause the browser to show an builtin error page instead of continuing to retry
+      server.httpServer?.on("listening", async () => {
+        const address = server.httpServer?.address();
+        const port = typeof address === "string" ? address : address?.port;
+        await fetch(`http://localhost:${port}/__vite_ping`);
+        ready = true;
+      });
+    },
+  };
+};

--- a/experiments/rsc/scripts/runDevServer.mts
+++ b/experiments/rsc/scripts/runDevServer.mts
@@ -10,10 +10,10 @@ const setup = async () => {
   await $`npx tsx ./scripts/buildVendorBundles.mts`;
 
   // context(justinvdm, 2024-11-28): Types don't affect runtime, so we don't need to block the dev server on them
-  //void codegenTypes();
+  void codegenTypes();
 };
 
-const runDevServer = async () => {
+export const runDevServer = async () => {
   const server = await createViteServer(viteConfigs.dev({ setup }));
   await server.listen();
 


### PR DESCRIPTION
Adds a vite plugin that will restart the dev server if any configs change (any js, ts or json file in root dir or in `scripts/`).

## Approach
* When a config file changes, close the dev server cleanly.
* Have the `pnpm dev` script in `package.json` re-run the script if it closed with a zero exit code => the user didn't Ctrl-C, and the script didn't exit with an error.
* Leverage Vite HMR browser client auto-retry capabilities to reload the page when the server is running again

## Notes
Ideally we could just use vite's `server.restart()`. I wasn't able to get this working - I got some obscure C error from workerd and didn't investigate further. That said, I think restarting the actual process is likely more robust, we can be more sure in this case that we're running on the latest changes.