### PR TITLE
feat: Support worker script runs + in-worker seed script

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "build": "npx tsx ./scripts/build.mts",
     "dev": "while true; do NODE_ENV=development npx tsx ./scripts/runDevServer.mts; [ $? -eq 0 ] || break; done",
-    "seed": "pnpm wrangler d1 execute DB --file ./migrations/seed.sql",
+    "seed": "pnpm worker:run ./src/scripts/seed.ts",
     "migrate:dev": "npx wrangler d1 migrations apply DB --local",
     "migrate:prd": "npx wrangler d1 migrations apply DB --remote",
     "migrate:new": "npx tsx ./scripts/migrateNew.mts",
+    "worker:run": "npx tsx ./scripts/runWorkerScript.mts",
     "codegen": "npx tsx ./scripts/codegen.mts",
     "types": "pnpm codegen:types && tsc",
     "deploy": "wrangler deploy",

--- a/experiments/billable/scripts/codegen.mts
+++ b/experiments/billable/scripts/codegen.mts
@@ -1,16 +1,18 @@
 import { $ } from "./lib/$.mjs";
 
-export const codegen = async () => {
-  console.log("Generating types...");
-  console.log("Generating db types...");
+export const codegen = async ({ silent = false }: { silent?: boolean } = {}) => {
+  const log = silent ? () => { } : console.log;
+
+  log("Generating types...");
+  log("Generating db types...");
 
   await $`pnpm prisma generate`;
 
-  console.log("Generating wrangler types...");
+  log("Generating wrangler types...");
   await $`pnpm wrangler types`;
 
-  console.log("Types generated!");
-  console.log();
+  log("Types generated!");
+  log();
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {

--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import { readFileSync } from 'fs';
 import { EventEmitter } from "node:events";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
@@ -207,10 +206,12 @@ const createDevEnv = async ({
       return redirectToSelf(request);
     }
 
-    request.headers.set(
-      "x-vite-fetch",
-      JSON.stringify({ entry } satisfies FetchMetadata),
-    );
+    if (!request.headers.has("x-vite-fetch")) {
+      request.headers.set(
+        "x-vite-fetch",
+        JSON.stringify({ entry } satisfies FetchMetadata),
+      );
+    }
 
     try {
       return await runnerWorker.fetch(request.url, request);

--- a/experiments/billable/scripts/lib/vitePlugins/restartPlugin.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/restartPlugin.mts
@@ -1,4 +1,4 @@
-import { HotUpdateOptions, Plugin } from "vite";
+import { Plugin } from "vite";
 import colors from "picocolors";
 import { getShortName } from "../getShortName.mjs";
 

--- a/experiments/billable/scripts/runDevServer.mts
+++ b/experiments/billable/scripts/runDevServer.mts
@@ -3,26 +3,42 @@ import { createServer as createViteServer } from "vite";
 import { viteConfigs } from "./configs/vite.mjs";
 import { codegen } from "./codegen.mjs";
 import { $ } from "./lib/$.mjs";
-import { DEV_SERVER_PORT } from "./lib/constants.mjs";
 
-const setup = async () => {
+const setup = ({ silent = false } = {}) => async () => {
   // context(justinvdm, 2024-12-05): Call indirectly to silence verbose output when VERBOSE is not set
   await $`npx tsx ./scripts/buildVendorBundles.mts`;
 
   // context(justinvdm, 2024-11-28): Types don't affect runtime, so we don't need to block the dev server on them
-  void codegen();
+  void codegen({ silent });
 };
 
-export const runDevServer = async () => {
-  const server = await createViteServer(viteConfigs.dev({ setup }));
-  await server.listen();
+export const runDevServer = async ({ isMain = false } = {}) => {
+  const silent = !isMain;
 
-  console.log(`\
+  const server = await createViteServer(viteConfigs.dev({
+    setup: setup({ silent }),
+    silent,
+    port: 0,
+    restartOnChanges: isMain,
+  }));
+
+  await server.listen();
+  const address = server.httpServer?.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Dev server address is invalid');
+  }
+
+  if (!silent) {
+    console.log(`\
 🚀 Dev server ready!
-⭐️ Local: http://localhost:${DEV_SERVER_PORT}
+⭐️ Local: http://localhost:${address.port}
   `);
+  }
+
+  return server
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
-  runDevServer();
+  runDevServer({ isMain: true });
 }

--- a/experiments/billable/scripts/runWorkerScript.mts
+++ b/experiments/billable/scripts/runWorkerScript.mts
@@ -8,7 +8,7 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
     console.log('\nUsage:');
     console.log('  pnpm worker:run <script-path>');
     console.log('\nExample:');
-    console.log('  pnpm worker:run src/workers/myScript.ts\n');
+    console.log('  pnpm worker:run src/scripts/seed.ts\n');
     process.exit(1);
   }
 

--- a/experiments/billable/scripts/runWorkerScript.mts
+++ b/experiments/billable/scripts/runWorkerScript.mts
@@ -1,0 +1,36 @@
+import { resolve } from 'path'
+import { ROOT_DIR } from './lib/constants.mjs';
+import { runDevServer } from './runDevServer.mjs';
+
+export const runWorkerScript = async (relativeScriptPath: string) => {
+  if (!relativeScriptPath) {
+    console.error('Error: Script path is required');
+    console.log('\nUsage:');
+    console.log('  pnpm worker:run <script-path>');
+    console.log('\nExample:');
+    console.log('  pnpm worker:run src/workers/myScript.ts\n');
+    process.exit(1);
+  }
+
+  const scriptPath = resolve(ROOT_DIR, relativeScriptPath);
+  const server = await runDevServer();
+  const address = server.httpServer?.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Dev server address is invalid');
+  }
+
+  await fetch(`http://localhost:${address.port}/`, {
+    headers: {
+      'x-vite-fetch': JSON.stringify({
+        entry: scriptPath,
+      }),
+    },
+  })
+
+  await server.close()
+};
+
+if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {
+  runWorkerScript(process.argv[2])
+}

--- a/experiments/billable/scripts/runWorkerScript.mts
+++ b/experiments/billable/scripts/runWorkerScript.mts
@@ -14,21 +14,25 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
 
   const scriptPath = resolve(ROOT_DIR, relativeScriptPath);
   const server = await runDevServer();
-  const address = server.httpServer?.address();
 
-  if (!address || typeof address === 'string') {
-    throw new Error('Dev server address is invalid');
+  try {
+    const address = server.httpServer?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Dev server address is invalid');
+    }
+
+    await fetch(`http://localhost:${address.port}/`, {
+      headers: {
+        'x-vite-fetch': JSON.stringify({
+          entry: scriptPath,
+        }),
+      },
+    })
+
+  } finally {
+    await server.close()
   }
-
-  await fetch(`http://localhost:${address.port}/`, {
-    headers: {
-      'x-vite-fetch': JSON.stringify({
-        entry: scriptPath,
-      }),
-    },
-  })
-
-  await server.close()
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {

--- a/experiments/billable/src/scripts/defineScript.ts
+++ b/experiments/billable/src/scripts/defineScript.ts
@@ -1,0 +1,11 @@
+import { setupDb } from '../db';
+
+export const defineScript = (fn: ({ env }: { env?: Env }) => Promise<unknown>) => {
+  return {
+    async fetch(request: Request, env: Env) {
+      setupDb(env);
+      await fn({ env });
+      return new Response('Done!')
+    },
+  };
+};

--- a/experiments/billable/src/scripts/seed.ts
+++ b/experiments/billable/src/scripts/seed.ts
@@ -1,0 +1,15 @@
+import { db } from '../db';
+import { defineScript } from './defineScript';
+
+export default defineScript(async () => {
+  await db.user.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      id: 1,
+      email: 'test@test.com',
+    },
+  });
+
+  console.log('Done seeding!')
+})

--- a/experiments/rsc/scripts/codegen.mts
+++ b/experiments/rsc/scripts/codegen.mts
@@ -1,16 +1,17 @@
 import { $ } from "./lib/$.mjs";
+import { log } from '../../billable/scripts/lib/log.mjs';
 
 export const codegen = async () => {
-  console.log("Generating types...");
-  console.log("Generating db types...");
+  log("Generating types...");
+  log("Generating db types...");
 
   await $`pnpm prisma generate`;
 
-  console.log("Generating wrangler types...");
+  log("Generating wrangler types...");
   await $`pnpm wrangler types`;
 
-  console.log("Types generated!");
-  console.log();
+  log("Types generated!");
+  log();
 };
 
 if (import.meta.url === new URL(process.argv[1], import.meta.url).href) {


### PR DESCRIPTION
<img width="341" alt="Screenshot 2025-01-08 at 13 24 05" src="https://github.com/user-attachments/assets/8dc8d472-40de-4909-bdde-108041d98d41" />

<img width="974" alt="Screenshot 2025-01-08 at 13 10 30" src="https://github.com/user-attachments/assets/6600693e-3cfc-4ef5-86f7-0655b0d1358f" />

## Video with context
https://app.claap.io/na-58/c-qkcr0NJtVm-fWkblyclDUP8

## Changes
* Allows us to write and run scripts that run _within_ the worker (inside the miniflare sandbox).
* Adds a `seed.ts` example script and changes `pnpm seed` to use it
* More context on the approach in [the video](https://app.claap.io/na-58/c-qkcr0NJtVm-fWkblyclDUP8
)!

Solves #34 