### PR TITLE
fix: Fix client side

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -64,6 +64,7 @@
   "scripts": {
     "build": "npx tsx ./scripts/build.mts",
     "build:vendor": "npx tsx ./scripts/buildVendorBundles.mts",
+    "build:clean": "rm -f clean:vendor && rm -f clean:vite",
     "dev": "while true; do NODE_ENV=development npx tsx ./scripts/runDevServer.mts; [ $? -eq 0 ] || break; done",
     "seed": "pnpm worker:run ./src/scripts/seed.ts",
     "migrate:dev": "npx wrangler d1 migrations apply DB --local",
@@ -72,6 +73,8 @@
     "worker:run": "npx tsx ./scripts/runWorkerScript.mts",
     "codegen": "npx tsx ./scripts/codegen.mts",
     "types": "pnpm codegen:types && tsc",
+    "clean:vite": "rm -rf ./node_modules/.vite",
+    "clean:vendor": "rm -rf ./vendor/dist",
     "deploy": "wrangler deploy",
     "preview": "NODE_ENV=${NODE_ENV:-development} PREVIEW=1 npx tsx ./scripts/runPreviewServer.mts",
     "format": "npx prettier --write ./src ./scripts"

--- a/experiments/billable/scripts/configs/vite.mts
+++ b/experiments/billable/scripts/configs/vite.mts
@@ -15,6 +15,7 @@ import tailwind from "tailwindcss";
 import autoprefixer from "autoprefixer";
 import reactPlugin from "@vitejs/plugin-react";
 
+import { aliasByEnvPlugin } from "../lib/vitePlugins/aliasByEnvPlugin.mjs";
 import { transformJsxScriptTagsPlugin } from "../lib/vitePlugins/transformJsxScriptTagsPlugin.mjs";
 import { useServerPlugin } from "../lib/vitePlugins/useServerPlugin.mjs";
 import { useClientPlugin } from "../lib/vitePlugins/useClientPlugin.mjs";
@@ -42,7 +43,12 @@ export const viteConfigs = {
       ),
       "process.env.NODE_ENV": JSON.stringify(MODE),
     },
-    plugins: [reactPlugin(), useServerPlugin(), useClientPlugin()],
+    plugins: [reactPlugin(), useServerPlugin(), useClientPlugin(), aliasByEnvPlugin({
+      worker: {
+        react: resolve(VENDOR_DIST_DIR, "react-rsc.js"),
+        'vendor/react-ssr': resolve(VENDOR_DIST_DIR, "react-ssr.js"),
+      }
+    })],
     environments: {
       client: {
         consumer: "client",
@@ -91,15 +97,6 @@ export const viteConfigs = {
           },
         },
       },
-    },
-    resolve: {
-      alias: [{
-        find: "vendor/react-ssr",
-        replacement: resolve(VENDOR_DIST_DIR, "react-ssr.js"),
-      }, {
-        find: /^react$/,
-        replacement: resolve(VENDOR_DIST_DIR, "react-rsc.js"),
-      }]
     },
     server: {
       hmr: true,

--- a/experiments/billable/scripts/lib/vitePlugins/aliasByEnvPlugin.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/aliasByEnvPlugin.mts
@@ -1,0 +1,15 @@
+import { Plugin } from "vite";
+
+export const aliasByEnvPlugin = (aliasesByEnv: Record<string, Record<string, string>>): Plugin => ({
+  name: "rw-reloaded-env-alias",
+
+  enforce: 'pre',
+
+  resolveId(id) {
+    const aliases = aliasesByEnv[this.environment.name] ?? {};
+    const alias = aliases[id];
+    if (alias) {
+      return alias;
+    }
+  }
+});

--- a/experiments/billable/scripts/runDevServer.mts
+++ b/experiments/billable/scripts/runDevServer.mts
@@ -5,6 +5,8 @@ import { codegen } from "./codegen.mjs";
 import { $ } from "./lib/$.mjs";
 
 const setup = ({ silent = false } = {}) => async () => {
+  await $`pnpm build:clean`;
+
   // context(justinvdm, 2024-12-05): Call indirectly to silence verbose output when VERBOSE is not set
   await $`pnpm build:vendor`;
 

--- a/experiments/billable/src/app/pages/invoiceDetail/FetchInvoice.tsx
+++ b/experiments/billable/src/app/pages/invoiceDetail/FetchInvoice.tsx
@@ -1,11 +1,8 @@
 "use server";
 
-import React from "react";
 import { getInvoice } from "../../services/invoices";
 
-export function FetchInvoice(props: { id: number, children: Function }) {
-
-  const invoice = React.use(getInvoice(props.id, 1));
+export async function FetchInvoice(props: { id: number, children: Function }) {
+  const invoice = await getInvoice(props.id, 1);
   return props.children(invoice)
 }
-

--- a/experiments/billable/src/app/services/invoices.ts
+++ b/experiments/billable/src/app/services/invoices.ts
@@ -15,10 +15,10 @@ export async function getInvoiceListSummary(userId: number) {
     where: {
       userId
     }
-  })
+  }) ?? []
   return invoices.map((invoice) => {
 
-    const { id, date, number, customer, status} = invoice
+    const { id, date, number, customer, status } = invoice
 
     // const subtotal = calculateSubtotal(invoice.items as InvoiceItem[])
     // const taxes = calculateTaxes(subtotal, invoice.taxes as InvoiceTaxItem[])


### PR DESCRIPTION
 ## Problem
I added a fix in #36 (https://github.com/redwoodjs/reloaded/pull/36/commits/44632d7973110fe4b72fd4037ff54e1cde31627f) that caused us to always resolve react to a custom build of react. This custom build caters for the fact that RSC and SSR are sharing a runtime.

However, I accidentally made the client side bundling also use this custom build of react, rather than normal react.

 ## Solution

I've added a plugin that allows us to alias react to the custom build of react only for the worker side, but leave it alone on the client side.

 ## Note
While fixing this, I discovered that the current way of having RSC and SSR share a single react build will not work for all things. For example, if there is a `use()` call in SSR-rendered code, we will end up with an issue because RSC is expecting its `use()`` and not the SSR `use()`.

I'll work on fixing this in a future PR.