### PR TITLE
fix: Fix miniflare plugin HMR breaking on some updates

### DIFF
--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -544,14 +544,16 @@ export const miniflarePlugin = async (
         const m = ctx.server.environments.client.moduleGraph
           .getModulesByFile(resolve(SRC_DIR, "app", "style.css"))
           ?.values()
-          .next().value!;
+          .next().value;
 
-        ctx.server.environments.client.moduleGraph.invalidateModule(
-          m,
-          new Set(),
-          ctx.timestamp,
-          true,
-        );
+        if (m) {
+          ctx.server.environments.client.moduleGraph.invalidateModule(
+            m,
+            new Set(),
+            ctx.timestamp,
+            true,
+          );
+        }
 
         ctx.server.environments.client.hot.send({
           type: "custom",

--- a/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -544,14 +544,16 @@ export const miniflarePlugin = async (
         const m = ctx.server.environments.client.moduleGraph
           .getModulesByFile(resolve(SRC_DIR, "app", "style.css"))
           ?.values()
-          .next().value!;
+          .next().value;
 
-        ctx.server.environments.client.moduleGraph.invalidateModule(
-          m,
-          new Set(),
-          ctx.timestamp,
-          true,
-        );
+        if (m) {
+          ctx.server.environments.client.moduleGraph.invalidateModule(
+            m,
+            new Set(),
+            ctx.timestamp,
+            true,
+          );
+        }
 
         ctx.server.environments.client.hot.send({
           type: "custom",


### PR DESCRIPTION
We invalidate the style module for the client environment when the worker has been updated -
since there may have been changes to class usages in the app code, which can result in differences to the stylesheet.

Problem is, the client environment might not yet have the style module in its module graph, so we need to check for that before trying invalidating.

Solves the issue where we see this during `pnpm dev`

```
[vite] Internal Server Error
Cannot read properties of undefined (reading 'invalidationState')
    at EnvironmentModuleGraph.invalidateModule (/Users/justin/rw/reloaded/experiments/textify/node_modules/.pnpm/vite@6.0.0_@types+node@22.9.0_jiti@1.21.6_terser@5.36.0_tsx@4.19.2_yaml@2.6.1/node_modules/vite/dist/node/chunks/dep-C6qYk3zB.js:51820:39)
```