### PR TITLE
fix: Allow for cloudflare worker handlers other than fetch

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.48.0",
     "@types/express": "^5.0.0",
+    "@types/fnv-plus": "^1.3.2",
     "@types/fs-extra": "^11.0.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -36,6 +37,7 @@
     "es-module-lexer": "^1.5.4",
     "execa": "^9.5.1",
     "express": "^4.21.1",
+    "fnv-plus": "^1.3.1",
     "fs-extra": "^11.2.0",
     "import-meta-resolve": "^4.1.0",
     "kysely-codegen": "^0.17.0",

--- a/experiments/billable/pnpm-lock.yaml
+++ b/experiments/billable/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
+      '@types/fnv-plus':
+        specifier: ^1.3.2
+        version: 1.3.2
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -84,6 +87,9 @@ importers:
       express:
         specifier: ^4.21.1
         version: 4.21.1
+      fnv-plus:
+        specifier: ^1.3.1
+        version: 1.3.1
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -996,6 +1002,9 @@ packages:
   '@types/express@5.0.0':
     resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
 
+  '@types/fnv-plus@1.3.2':
+    resolution: {integrity: sha512-Bgr5yn2dph2q8HZKDS002Pob6vaRTRfhqN9E+TOhjKsJvnfZXULPR3ihH8dL5ZjgxbNhqhTn9hijpbAMPtKZzw==}
+
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
@@ -1596,6 +1605,9 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  fnv-plus@1.3.1:
+    resolution: {integrity: sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw==}
 
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
@@ -3469,6 +3481,8 @@ snapshots:
       '@types/qs': 6.9.17
       '@types/serve-static': 1.15.7
 
+  '@types/fnv-plus@1.3.2': {}
+
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
@@ -4207,6 +4221,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  fnv-plus@1.3.1: {}
 
   foreground-child@3.3.0:
     dependencies:

--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -362,7 +362,7 @@ const createDevEnv = async ({
     }
 
     try {
-      return await runnerDO.fetch(request.url, request);
+      return await miniflare.dispatchFetch(request.url, request as any)
     } catch (e) {
       if (devEnv.discarded) {
         return redirectToSelf(request);

--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/runner.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/runner.mts
@@ -1,5 +1,5 @@
-import { DurableObject } from "cloudflare:workers";
-import { RunnerEnv, RunnerRpc } from "./types.mjs";
+import { DurableObject } from "cloudflare:workers"
+import { RunnerEnv } from "./types.mjs";
 import {
   ModuleEvaluator,
   ModuleRunner,
@@ -9,50 +9,80 @@ import {
 } from "vite/module-runner";
 import { HotPayload } from "vite";
 
-let __viteModuleRunner: ModuleRunner | undefined = undefined
+const STATE: {
+  runner: ModuleRunner | undefined
+  handlers: ModuleRunnerTransportHandlers | undefined
+} = {
+  runner: undefined,
+  handlers: undefined,
+}
 
-export class RunnerDO
-  extends DurableObject<RunnerEnv>
-  implements RunnerRpc {
-  #runner?: ModuleRunner;
-  #handlers?: ModuleRunnerTransportHandlers;
+const fetch = async (request: Request<any, any>, env: RunnerEnv, ctx: ExecutionContext) => {
+  const {
+    entry,
+    instruction,
+  }: {
+    entry?: string
+    instruction: string
+  } = request.headers.get("x-vite-fetch") ? JSON.parse(request.headers.get("x-vite-fetch")!) : {}
 
-  async fetch(request: Request<any, any>) {
-    return fetch(request, this.env, {
-      waitUntil(_promise: Promise<any>) { },
-      passThroughOnException() { },
-    })
+  if (instruction === "proxy") {
+    return await proxyWorkerHandlerMethod({ methodName: "fetch" as const, entry, env, run: fn => fn(request, env, ctx) })
   }
 
-  async initRunner() {
-    const options: ModuleRunnerOptions = {
-      root: this.env.__viteRoot,
-      sourcemapInterceptor: "prepareStackTrace",
-      hmr: true,
-      transport: {
-        invoke: (payload) => {
-          return callBinding({
-            binding: this.env.__viteInvoke,
-            payload,
-          })
-        },
-        connect: (handlers) => {
-          this.#handlers = handlers;
-        },
-        send: (payload) =>
-          callBinding({ binding: this.env.__viteSendToServer, payload }),
+  if (instruction === "init") {
+    initRunner(env)
+    return new Response("OK")
+  }
+
+  if (instruction === "send") {
+    sendToRunner(await request.json())
+    return new Response("OK")
+  }
+
+  throw new Error(`Unknown instruction: ${instruction}`)
+}
+
+export default {
+  fetch,
+  ...Object.fromEntries(
+    (["tail", "trace", "scheduled", "test", "email", "queue"] as const)
+      .map(methodName => [
+        methodName,
+        (arg0: any, env: RunnerEnv, ctx: ExecutionContext) => {
+          return proxyWorkerHandlerMethod({ methodName, env, run: fn => fn(arg0 as any, env, ctx) })
+        }
+      ])
+  ),
+}
+
+const initRunner = (env: RunnerEnv) => {
+  const options: ModuleRunnerOptions = {
+    root: env.__viteRoot,
+    sourcemapInterceptor: "prepareStackTrace",
+    hmr: true,
+    transport: {
+      invoke: (payload) => {
+        return callBinding({
+          binding: env.__viteInvoke,
+          payload,
+        })
       },
-    };
+      connect: (handlers) => {
+        STATE.handlers = handlers;
+      },
+      send: (payload) =>
+        callBinding({ binding: env.__viteSendToServer, payload }),
+    },
+  };
 
-    this.#runner = new ModuleRunner(options, createEvaluator(this.env));
-    __viteModuleRunner = this.#runner
-  }
+  STATE.runner = new ModuleRunner(options, createEvaluator(env));
+}
 
-  async sendToRunner(payload: HotPayload): Promise<void> {
-    // context(justinvdm, 10 Dec 2024): This is the handler side of the `sendToWorker` rpc method.
-    // We're telling the runner: "here's a message from the server, do something with it".
-    this.#handlers?.onMessage(payload);
-  }
+const sendToRunner = (payload: HotPayload) => {
+  // context(justinvdm, 10 Dec 2024): This is the handler side of the `sendToWorker` rpc method.
+  // We're telling the runner: "here's a message from the server, do something with it".
+  STATE.handlers?.onMessage(payload);
 }
 
 export const createEvaluator = (env: RunnerEnv): ModuleEvaluator => ({
@@ -150,12 +180,12 @@ export const proxyWorkerHandlerMethod = async <Env extends Record<string, unknow
   env: Env,
   run: (method: NonNullable<ExportedHandler<Env>[MethodName]>) => ReturnType<NonNullable<ExportedHandler<Env>[MethodName]>>
 }) => {
-  if (!__viteModuleRunner) {
+  if (!STATE.runner) {
     throw new Error("Runner not initialized");
   }
 
   const entry = entryOverride ?? env.__viteWorkerEntry as string;
-  const mod = await __viteModuleRunner.import(entry);
+  const mod = await STATE.runner?.import(entry);
 
   const handler = mod.default as ExportedHandler;
 
@@ -163,28 +193,7 @@ export const proxyWorkerHandlerMethod = async <Env extends Record<string, unknow
     throw new Error(`Worker does not have a ${methodName} method`);
   }
 
-  return run(handler[methodName]);
-}
-
-const fetch = (request: Request<any, any>, env: RunnerEnv, ctx: ExecutionContext) => {
-  const options = request.headers.get("x-vite-fetch") ? JSON.parse(request.headers.get("x-vite-fetch")!) : undefined
-  return proxyWorkerHandlerMethod({ methodName: "fetch" as const, entry: options?.entry, env, run: fn => fn(request, env, ctx) })
-}
-
-export default {
-  fetch,
-  tail: (events: TraceItem[], env: RunnerEnv, ctx: ExecutionContext) => {
-    return proxyWorkerHandlerMethod({ methodName: "tail" as const, env, run: fn => fn(events as any, env, ctx) })
-  },
-  trace: (traces: TraceItem[], env: RunnerEnv, ctx: ExecutionContext) => {
-    return proxyWorkerHandlerMethod({ methodName: "trace" as const, env, run: fn => fn(traces as any, env, ctx) })
-  },
-  scheduled: (controller: ScheduledController, env: RunnerEnv, ctx: ExecutionContext) => {
-    return proxyWorkerHandlerMethod({ methodName: "scheduled" as const, env, run: fn => fn(controller, env, ctx) })
-  },
-  test: (controller: TestController, env: RunnerEnv, ctx: ExecutionContext) => {
-    return proxyWorkerHandlerMethod({ methodName: "test" as const, env, run: fn => fn(controller, env, ctx) })
-  },
+  return await run(handler[methodName]);
 }
 
 export const createDurableObjectProxy = (scriptName: string, className: string) => {
@@ -195,11 +204,11 @@ export const createDurableObjectProxy = (scriptName: string, className: string) 
       return instance
     }
 
-    if (!__viteModuleRunner) {
+    if (!STATE.runner) {
       throw new Error("Runner not initialized");
     }
 
-    const mod = await __viteModuleRunner.import(scriptName)
+    const mod = await STATE.runner.import(scriptName)
     const Constructor = mod[className]
     instance = new Constructor(state, env)
     return instance

--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/types.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/types.mts
@@ -33,4 +33,4 @@ export type NoOptionals<T> = {
   [K in keyof T]-?: T[K];
 };
 
-export type RunnerWorkerApi = Fetcher & RunnerRpc;
+export type RunnerDOApi = Fetcher & RunnerRpc;

--- a/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/types.mts
+++ b/experiments/billable/scripts/lib/vitePlugins/miniflarePlugin/types.mts
@@ -24,13 +24,6 @@ export type RunnerEnv = {
   __viteClassName?: string;
 } & EnvServiceBindings;
 
-export type FetchMetadata = {
-  entry?: string;
-  className?: string;
-};
-
 export type NoOptionals<T> = {
   [K in keyof T]-?: T[K];
 };
-
-export type RunnerDOApi = Fetcher & RunnerRpc;

--- a/experiments/billable/scripts/runWorkerScript.mts
+++ b/experiments/billable/scripts/runWorkerScript.mts
@@ -26,6 +26,7 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
       headers: {
         'x-vite-fetch': JSON.stringify({
           entry: scriptPath,
+          instruction: "proxy",
         }),
       },
     })

--- a/experiments/textify/package.json
+++ b/experiments/textify/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.48.0",
     "@types/express": "^5.0.0",
+    "@types/fnv-plus": "^1.3.2",
     "@types/fs-extra": "^11.0.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -51,6 +52,7 @@
     "es-module-lexer": "^1.5.4",
     "execa": "^9.5.1",
     "express": "^4.21.1",
+    "fnv-plus": "^1.3.1",
     "fs-extra": "^11.2.0",
     "import-meta-resolve": "^4.1.0",
     "kysely-codegen": "^0.17.0",

--- a/experiments/textify/pnpm-lock.yaml
+++ b/experiments/textify/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
+      '@types/fnv-plus':
+        specifier: ^1.3.2
+        version: 1.3.2
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -75,6 +78,9 @@ importers:
       express:
         specifier: ^4.21.1
         version: 4.21.1
+      fnv-plus:
+        specifier: ^1.3.1
+        version: 1.3.1
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -987,6 +993,9 @@ packages:
   '@types/express@5.0.0':
     resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
 
+  '@types/fnv-plus@1.3.2':
+    resolution: {integrity: sha512-Bgr5yn2dph2q8HZKDS002Pob6vaRTRfhqN9E+TOhjKsJvnfZXULPR3ihH8dL5ZjgxbNhqhTn9hijpbAMPtKZzw==}
+
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
@@ -1584,6 +1593,9 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  fnv-plus@1.3.1:
+    resolution: {integrity: sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw==}
 
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
@@ -3452,6 +3464,8 @@ snapshots:
       '@types/qs': 6.9.17
       '@types/serve-static': 1.15.7
 
+  '@types/fnv-plus@1.3.2': {}
+
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
@@ -4188,6 +4202,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  fnv-plus@1.3.1: {}
 
   foreground-child@3.3.0:
     dependencies:

--- a/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -362,7 +362,7 @@ const createDevEnv = async ({
     }
 
     try {
-      return await runnerDO.fetch(request.url, request);
+      return await miniflare.dispatchFetch(request.url, request as any)
     } catch (e) {
       if (devEnv.discarded) {
         return redirectToSelf(request);

--- a/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
+++ b/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/plugin.mts
@@ -28,9 +28,7 @@ import {
 } from "vite";
 import { nodeToWebRequest, webToNodeResponse } from "../requestUtils.mjs";
 import {
-  FetchMetadata,
   NoOptionals,
-  RunnerDOApi,
   ServiceBindings,
 } from "./types.mjs";
 import { compileTsModule } from "../../compileTsModule.mjs";
@@ -159,19 +157,18 @@ const generateViteRunnerScript = async ({ workerOptions, options }: { workerOpti
   const contents = await readTsModule("./runner.mts");
   const durableObjectDescriptors = normalizeDurableObjectDescriptors({ workerOptions, options });
 
+  const getDOIdentifier = (scriptName: string, className: string) => `${scriptName}__${className}`
+
   const code = [
     contents,
-    ...durableObjectDescriptors.map(({ scriptName, className }) => `export const ${className} = createDurableObjectProxy(${JSON.stringify(scriptName)}, ${JSON.stringify(className)});`),
+    ...durableObjectDescriptors.map(({ name, scriptName, className }) => `export const ${getDOIdentifier(scriptName, className)} = createDurableObjectProxy(${JSON.stringify(scriptName)}, ${JSON.stringify(className)});`),
   ].join('\n')
 
-  const durableObjects = Object.fromEntries(durableObjectDescriptors.map(({ name, className }) => [name, className]))
+  const durableObjects = Object.fromEntries(durableObjectDescriptors.map(({ name, scriptName, className }) => [name, getDOIdentifier(scriptName, className)]))
 
   return {
     code,
-    durableObjects: {
-      ...durableObjects,
-      __viteRunner: "RunnerDO",
-    },
+    durableObjects,
   }
 }
 
@@ -257,9 +254,9 @@ const createMiniflareOptions = async ({
 };
 
 const createTransport = ({
-  runnerDO,
+  sendToRunner,
 }: {
-  runnerDO: RunnerDOApi;
+  sendToRunner: (data: HotPayload) => Promise<unknown>;
 }): {
   hotDispatch: HotDispatcher;
   transport: HotChannel;
@@ -280,7 +277,7 @@ const createTransport = ({
       close: () => { },
       on: events.on.bind(events),
       off: events.off.bind(events),
-      send: runnerDO.sendToRunner.bind(runnerDO),
+      send: sendToRunner,
     },
   };
 };
@@ -320,7 +317,7 @@ const createDevEnv = async ({
     },
     __viteSendToServer: async (request) => {
       const payload = (await request.json()) as HotPayload;
-      hotDispatch(payload, { send: runnerDO.sendToRunner });
+      hotDispatch(payload, { send: sendToRunner });
       return Response.json(null);
     },
   };
@@ -333,10 +330,33 @@ const createDevEnv = async ({
     }),
   );
 
-  const ns = await miniflare.getDurableObjectNamespace("__viteRunner");
-  const runnerDO = ns.get(ns.idFromName("")) as unknown as RunnerDOApi;
+  const sendInstruction = async ({ instruction, entry, data }: { instruction: string, entry?: string, data?: unknown }) => {
+    return await miniflare.dispatchFetch("https://any.local", {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "x-vite-fetch": JSON.stringify({
+          instruction,
+          entry,
+        }),
+      },
+    });
+  }
 
-  const { hotDispatch, transport } = createTransport({ runnerDO });
+  const sendToRunner = async (data: HotPayload) => {
+    return await sendInstruction({
+      instruction: "send",
+      data,
+    });
+  }
+
+  const initRunner = async () => {
+    return await sendInstruction({
+      instruction: "init",
+    });
+  }
+
+  const { hotDispatch, transport } = createTransport({ sendToRunner });
 
   const redirectToSelf = async (req: Request) => {
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -357,12 +377,15 @@ const createDevEnv = async ({
     if (!request.headers.has("x-vite-fetch")) {
       request.headers.set(
         "x-vite-fetch",
-        JSON.stringify({ entry } satisfies FetchMetadata),
+        JSON.stringify({
+          entry,
+          instruction: "proxy",
+        }),
       );
     }
 
     try {
-      return await miniflare.dispatchFetch(request.url, request as any)
+      return await miniflare.dispatchFetch(request.url, request as any) as unknown as Response
     } catch (e) {
       if (devEnv.discarded) {
         return redirectToSelf(request);
@@ -391,7 +414,7 @@ const createDevEnv = async ({
     transport,
   });
 
-  await runnerDO.initRunner();
+  await initRunner();
 
   return devEnv;
 };

--- a/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/types.mts
+++ b/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/types.mts
@@ -33,4 +33,4 @@ export type NoOptionals<T> = {
   [K in keyof T]-?: T[K];
 };
 
-export type RunnerWorkerApi = Fetcher & RunnerRpc;
+export type RunnerDOApi = Fetcher & RunnerRpc;

--- a/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/types.mts
+++ b/experiments/textify/scripts/lib/vitePlugins/miniflarePlugin/types.mts
@@ -24,13 +24,6 @@ export type RunnerEnv = {
   __viteClassName?: string;
 } & EnvServiceBindings;
 
-export type FetchMetadata = {
-  entry?: string;
-  className?: string;
-};
-
 export type NoOptionals<T> = {
   [K in keyof T]-?: T[K];
 };
-
-export type RunnerDOApi = Fetcher & RunnerRpc;

--- a/experiments/textify/scripts/runWorkerScript.mts
+++ b/experiments/textify/scripts/runWorkerScript.mts
@@ -26,6 +26,7 @@ export const runWorkerScript = async (relativeScriptPath: string) => {
       headers: {
         'x-vite-fetch': JSON.stringify({
           entry: scriptPath,
+          instruction: "proxy",
         }),
       },
     })

--- a/experiments/textify/src/worker.tsx
+++ b/experiments/textify/src/worker.tsx
@@ -26,6 +26,17 @@ export default {
       setupAI(env);
       setupDb(env);
 
+      if (request.url.includes("/test")) {
+        await env.ai_que.send({ 
+          from: "test",
+          messageSid: "test",
+          queue: "message-que",
+          input: {
+            text: "test",
+          },
+        });
+        return new Response('OK', { status: 200 });
+      }
 
       if (request.method === "POST" && request.url.includes("/incoming")) {
         console.log("Incoming request received");
@@ -168,7 +179,7 @@ export default {
         }
       }
 
-      return new Response(null, { status: 200 });
+      return new Response('OK', { status: 200 });
     } catch (e) {
       console.error("Unhandled error", e);
       throw e;


### PR DESCRIPTION
## Context
In order to get vite HMR and miniflare to work together, we need to have a wrapper entry point module, which will import and run the relevant code dynamically, leveraging vite dev server for loading the modules.

The way we were defining this wrapper was with a durable object. We exposed methods on the durable object for initialization (we need to create a vite "module runner" inside miniflare), as well as sending messages from vite into miniflare. This way, we can get at the "stub" of the durable object instance outside of miniflare, to call those methods via RPC. In other words, defining methods on a durable object and then calling them from outside of miniflare is one way to hook vite dev server up to code running inside of miniflare. This approach is what the vite team use in [their workerd example](https://github.com/hi-ogawa/vite-environment-examples/blob/81f30c9f9618878fd823a28d5970d6432d0d7002/packages/workerd/src/worker.ts#L15).

## Problem
The problem with this approach, is that DurableObjects don't expose the same handlers as workers do. They both can provide a `fetch()` handler, but for e.g. workers have a `queue()` handler and DurableObjects don't.

As a result, we weren't able to use things like `queue()` in dev.

## Solution
[Cloudflare's vite plugin](https://github.com/flarelabs-net/vite-plugin-cloudflare/blob/2876d044a1d815326b076175a7d1f3444ee47c59/packages/vite-plugin-cloudflare/src/runner-worker/index.ts) contrasts this approach by instead defining an actual worker when wrapping workers, and wrapping around DO's for DO's  (sensible right). As such, they don't have the same issue.

So in this PR, we solve the problem the same way as CF do basically.

Since we no longer have a durable object as the main wrapper, we now need a new way of calling methods that are in the miniflare sandbox from outside of miniflare. The way this PR solves this is by issuing these as internal requests to the wrapper worker, which instead of proxying those requests to the wrapped worker, do the internal work we're wanting it to do (e.g. instantiate the vite module runner)