### PR TITLE
fix: Work around prisma WASM hang

### DIFF
--- a/experiments/billable/src/worker.tsx
+++ b/experiments/billable/src/worker.tsx
@@ -44,6 +44,19 @@ export default {
       setupDb(env);
       setupEnv(env);
 
+      // todo(justinvdm, 30 Jan 2025): Figure out how to avoid this.
+      //
+      // ## Context:
+      // Vite sends an initial request to the worker when running the dev server,
+      // at which point the Prisma WASM is imported. Using the Prisma for the first time _after_ this initial request
+      // (e.g. if we only run the db for a request to /some/subpath) causes vite to not try import the WASM module
+      // at all, and ultimately the request ends up hanging indefinetely.
+      // * However, once the WASM has been imported, it is cached in some way that persists on the file system
+      // (from experimentation, it is not in node_modules/.vite). This means that if you were to subsequently
+      // change the code to _not_ have Prisma used after the initial request, the WASM will still be cached and
+      // the request will not hang. This makes this issue particularly hard to debug.
+      await db.$queryRaw`SELECT 1`
+
       const url = new URL(request.url);
       let ctx: Awaited<ReturnType<typeof getContext>> = {};
       let session: Awaited<ReturnType<typeof getSession>> | undefined;


### PR DESCRIPTION
 ## Context:
* Vite sends an initial request to the worker when running the dev server, at which point the Prisma WASM is imported. Using the Prisma for the first time _after_ this initial request (e.g. if we only run the db for a request to /some/subpath) causes vite to not try import the WASM module at all, and ultimately the request ends up hanging indefinetely.
* However, once the WASM has been imported, it is cached in some way that persists on the file system (from experimentation, it is not in node_modules/.vite). This means that if you were to subsequently change the code to _not_ have Prisma used after the initial request, the WASM will still be cached and the request will not hang. This makes this issue particularly hard to debug.
* To work around this, we run a `SELECT 1` query via Prisma at the start of the worker handler. I'll be looking more into this to find out what is doing this caching, and how we can avoid this workaround