### PR TITLE
fix: Deploys for billable

### DIFF
--- a/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceDetailPage.tsx
+++ b/experiments/billable/src/app/pages/invoice/DetailPage/InvoiceDetailPage.tsx
@@ -33,7 +33,7 @@ export async function getInvoice(id: string, userId: string) {
   };
 }
 
-export default async function InvoiceDetailPage({
+export async function InvoiceDetailPage({
   params,
   ctx,
 }: RouteContext<{ id: string }>) {

--- a/experiments/billable/src/app/pages/invoice/ListPage/InvoiceListPage.tsx
+++ b/experiments/billable/src/app/pages/invoice/ListPage/InvoiceListPage.tsx
@@ -57,7 +57,7 @@ async function getInvoiceListSummary(userId: string) {
   });
 }
 
-export default async function InvoiceListPage({ ctx }: RouteContext) {
+export async function InvoiceListPage({ ctx }: RouteContext) {
   const invoices = await getInvoiceListSummary(ctx.user.id);
   return (
     <Layout ctx={ctx}>

--- a/experiments/billable/src/app/pages/invoice/routes.ts
+++ b/experiments/billable/src/app/pages/invoice/routes.ts
@@ -1,6 +1,6 @@
 import { db, index, route } from "@redwoodjs/reloaded/worker";
-import InvoiceDetailPage from "./DetailPage/InvoiceDetailPage";
-import InvoiceListPage from "./ListPage/InvoiceListPage";
+import { InvoiceDetailPage } from "./DetailPage/InvoiceDetailPage";
+import { InvoiceListPage } from "./ListPage/InvoiceListPage";
 
 export const invoiceRoutes = [
   index(function () {


### PR DESCRIPTION
We currently have an issue with `"use server"` modules where we cannot use `export default`s, only `export`s.

This PR avoids the issue by changing the relevant `export default`s to `export`s. #84 tracks solving the actual issue for future cases.