### PR TITLE
fix: Fix billable after refactoring out reloaded runtime

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -52,7 +52,8 @@
     "vite": "^6.0.11",
     "wrangler": "^3.105.1",
     "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1"
+    "@types/react-dom": "^18.3.1",
+    "prisma": "^6.3.1"
   },
   "prisma": {
     "seed": "pnpm seed"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.5(@types/react@18.3.18)
+      prisma:
+        specifier: ^6.3.1
+        version: 6.3.1(typescript@5.7.3)
       vite:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@22.10.6)(jiti@1.21.7)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)

--- a/reloaded/package.json
+++ b/reloaded/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "pnpm build:src && pnpm build:vendor",
     "build:src": "tsc --build --clean && tsc",
-    "build:vendor": "node ./dist/scripts/buildVendorBundles.mjs",
+    "build:vendor": "node ./dist/scripts/build-vendor-bundles.mjs",
     "clean:vendor": "rm -rf ./vendor/dist"
   },
   "exports": {

--- a/reloaded/src/worker/db.ts
+++ b/reloaded/src/worker/db.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error PrismaClient is generated in the application codebase
 import { PrismaClient } from '@prisma/client'
 import { PrismaD1 } from '@prisma/adapter-d1'
 


### PR DESCRIPTION
* Fix path to build vendor bundles script (it was outdated)
* `@ts-expect-error` for prisma client imports in reloaded (since client generated in application)
* Bring prisma cli back as billable dev dep