### PR TITLE
fix: Include react-server-dom-webpack when optimizing deps

### DIFF
--- a/reloaded/src/vite/configPlugin.mts
+++ b/reloaded/src/vite/configPlugin.mts
@@ -3,11 +3,6 @@ import { resolve } from "node:path";
 import { createRequire } from "node:module";
 import { mergeConfig, InlineConfig } from 'vite';
 
-import tailwind from "tailwindcss";
-import autoprefixer from "autoprefixer";
-import reactPlugin from "@vitejs/plugin-react";
-import tsconfigPaths from "vite-tsconfig-paths";
-
 import {
   DEV_SERVER_PORT,
   VENDOR_DIST_DIR,
@@ -68,6 +63,7 @@ export const configPlugin = ({ mode,
               "react",
               "react/jsx-runtime",
               "react/jsx-dev-runtime",
+              "react-server-dom-webpack/server.edge",
               "react-dom/server.edge",
               "@prisma/client",
               "@redwoodjs/reloaded/worker",


### PR DESCRIPTION
After refactoring out reloaded runtime from billable, we now need to include react-server-dom-webpack in the optimized deps. I still need to figure out why, but in the meantime I'd like to unblock @peterp