### PR TITLE
fix: Ensure route handler does not mutate handlers array

### DIFF
--- a/reloaded/src/worker/lib/router.ts
+++ b/reloaded/src/worker/lib/router.ts
@@ -118,7 +118,7 @@ export function defineRoutes(routes: RouteDefinition[]): {
 
       // Array of handlers (middleware chain)
       if (Array.isArray(handler)) {
-        const handlers = handler;
+        const handlers = [...handler]
         handler = handlers.pop() as RouteFunction | RouteComponent;
 
         // loop over each function. Only the last function can be a page function.


### PR DESCRIPTION
There's a .pop() in the route handler on the handlers array, causing reruns of the same request to yield different results.

Reproduction + demo of fix: https://www.loom.com/share/e9a01b74965e4c979a47f61f6cd87801