### PR TITLE
fix: Only use custom react build for worker

### DIFF
--- a/experiments/billable/package.json
+++ b/experiments/billable/package.json
@@ -24,7 +24,8 @@
     "format": "prettier --write ./src",
     "__reset": "(cd ../../ && (cd reloaded && NODE_ENV=development pnpm build) && (cd experiments/billable && pnpm prisma generate && pnpm clean:vite))",
     "__reset:dev": "pnpm __reset && pnpm dev",
-    "__reset:build": "pnpm __reset && pnpm build"
+    "__reset:build": "pnpm __reset && pnpm build",
+    "__reset:release": "pnpm __reset && pnpm release"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241112.0",

--- a/reloaded/src/vite/configPlugin.mts
+++ b/reloaded/src/vite/configPlugin.mts
@@ -60,10 +60,8 @@ export const configPlugin = ({ mode,
               conditions: ["workerd", "react-server"],
             },
             include: [
-              "react",
               "react/jsx-runtime",
               "react/jsx-dev-runtime",
-              "react-dom/server.edge",
               "@prisma/client",
             ],
           },
@@ -88,16 +86,6 @@ export const configPlugin = ({ mode,
       },
       resolve: {
         dedupe: ["react", 'react-dom/server.edge', 'react-server-dom-webpack/server.edge'],
-        alias: [
-          {
-            find: /^react$/,
-            replacement: resolve(VENDOR_DIST_DIR, "react.js"),
-          },
-          {
-            find: /^react-dom\/(server|server\.edge)$/,
-            replacement: resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js"),
-          },
-        ],
       },
     };
 

--- a/reloaded/src/vite/customReactBuildPlugin.mts
+++ b/reloaded/src/vite/customReactBuildPlugin.mts
@@ -1,0 +1,50 @@
+import { resolve } from "path";
+import { Plugin } from "vite";
+
+import { VENDOR_DIST_DIR } from "../lib/constants.mjs";
+
+export const customReactBuildPlugin = (): Plugin => {
+  return {
+    name: "custom-react-build-plugin",
+    enforce: "pre",
+
+    resolveId(id) {
+      if (this.environment.name !== "worker") {
+        return;
+      }
+
+      if (id === "react") {
+        return resolve(VENDOR_DIST_DIR, "react.js");
+      }
+
+      if (id === "react-dom/server.edge" || id === "react-dom/server") {
+        return resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js");
+      }
+    },
+
+    config: () => ({
+      environments: {
+        worker: {
+          optimizeDeps: {
+            esbuildOptions: {
+              plugins: [
+                {
+                  name: "rewrite-react-imports",
+                  setup(build) {
+                    build.onResolve({ filter: /^react$/ }, (args) => {
+                      return { path: resolve(VENDOR_DIST_DIR, "react.js") };
+                    });
+
+                    build.onResolve({ filter: /^react-dom\/server\.edge$/ }, (args) => {
+                      return { path: resolve(VENDOR_DIST_DIR, "react-dom-server-edge.js") };
+                    });
+                  },
+                },
+              ],
+            }
+          }
+        }
+      },
+    }),
+  };
+};

--- a/reloaded/src/vite/redwoodPlugin.mts
+++ b/reloaded/src/vite/redwoodPlugin.mts
@@ -19,6 +19,7 @@ import { copyPrismaWasmPlugin } from "./copyPrismaWasmPlugin.mjs";
 import { moveStaticAssetsPlugin } from "./moveStaticAssetsPlugin.mjs";
 import { configPlugin } from "./configPlugin.mjs";
 import { $ } from '../lib/$.mjs';
+import { customReactBuildPlugin } from './customReactBuildPlugin.mjs';
 
 export type RedwoodPluginOptions = {
   silent?: boolean;
@@ -47,6 +48,7 @@ export const redwoodPlugin = (options: RedwoodPluginOptions = {}): InlineConfig[
       workerEntryPathname,
       port: options.port ?? DEV_SERVER_PORT,
     }),
+    customReactBuildPlugin(),
     tsconfigPaths({ root: projectRootDir }),
     miniflarePlugin({
       rootDir: projectRootDir,


### PR DESCRIPTION
We use a custom react build on cloudflare workers so that we can do RSC and SSR in the same runtime.

I accidentally had us using this same build for the client side too.

This PR makes it so that we only resolve to the custom build if we are in the worker environment.